### PR TITLE
Fix incorrect reference to ProfileTypeInterface

### DIFF
--- a/src/Access/ProfileAccessCheck.php
+++ b/src/Access/ProfileAccessCheck.php
@@ -13,7 +13,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\HttpFoundation\Request;
-use Drupal\profile\ProfileTypeInterface;
+use Drupal\profile\Entity\ProfileTypeInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 


### PR DESCRIPTION
Access check was failing due to old namespace path for ProfileTypeInterface.
